### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
     - linux
     - osx
 julia:
-    - release
+    - 0.4
 sudo: false
 notifications:
     email: false


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested